### PR TITLE
Updated to recommended syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ruby:2.3.3
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /app
 WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
 RUN bundle install
-ADD . /app
+COPY . /app
 EXPOSE 3000
-CMD rails s -p 3000
+CMD ["rails", "s", "-p", "3000"]


### PR DESCRIPTION
Atom.io was showing warnings about preferred syntax on the `CMD` syntax and on using `ADD` instead of `COPY`